### PR TITLE
Update libexif 0.2.36

### DIFF
--- a/recipes/libexif/all/conandata.yml
+++ b/recipes/libexif/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.6.22":
-    url: "https://github.com/libexif/libexif/releases/download/libexif-0_6_22-release/libexif-0.6.22.tar.gz"
-    sha256: "75dc5c135c61b5e0b15f3911b4de4b3070dd1a1683b9fc08d9ce3518d54d758d"
+  "0.6.23":
+    url: "https://github.com/libexif/libexif/releases/download/v0.6.23/libexif-0.6.23.tar.gz"
+    sha256: "9271cf58cb46b00f9e2e9b968c7d81c008a69e5457f7d1a50dbf1786eac61b52"

--- a/recipes/libexif/all/conanfile.py
+++ b/recipes/libexif/all/conanfile.py
@@ -62,8 +62,6 @@ class LibexifConan(ConanFile):
         return self._autotools
 
     def build(self):
-        with tools.chdir(self._source_subfolder):
-            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, win_bash=self._settings_build.os == "Windows")
         autotools = self._configure_autotools()
         autotools.make()
 

--- a/recipes/libexif/config.yml
+++ b/recipes/libexif/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.6.22":
+  "0.6.23":
     folder: all


### PR DESCRIPTION
- Using latest version available
- Don't need to run reconf